### PR TITLE
Ability to close the menus instantly without animation.

### DIFF
--- a/library/src/main/java/com/tubb/smrv/SwipeMenuLayout.java
+++ b/library/src/main/java/com/tubb/smrv/SwipeMenuLayout.java
@@ -96,6 +96,30 @@ public abstract class SwipeMenuLayout extends FrameLayout {
         smoothCloseMenu();
     }
 
+    public void openBeginMenuWithoutAnimation() {
+        if (mBeginSwiper == null) throw new IllegalArgumentException("No begin menu!");
+        mCurrentSwiper = mBeginSwiper;
+        smoothOpenMenu(0);
+    }
+
+    public void openEndMenuWithoutAnimation() {
+        if (mEndSwiper == null) throw new IllegalArgumentException("No end menu!");
+        mCurrentSwiper = mEndSwiper;
+        smoothOpenMenu(0);
+    }
+
+    public void closeBeginMenuWithoutAnimation() {
+        if (mBeginSwiper == null) throw new IllegalArgumentException("No begin menu!");
+        mCurrentSwiper = mBeginSwiper;
+        smoothCloseMenu(0);
+    }
+
+    public void closeEndMenuWithoutAnimation() {
+        if (mEndSwiper == null) throw new IllegalArgumentException("No end menu!");
+        mCurrentSwiper = mEndSwiper;
+        smoothCloseMenu(0);
+    }
+
     public abstract void smoothOpenMenu(int duration);
 
     public void smoothOpenMenu() {


### PR DESCRIPTION
When using SwipeMenu in RecyclerView we need to have the ability to instantly close the menus without animation, because when the views are recycled there could be a possibility, that a new item will have an open menu, because the view is recycled. To solve this we need to set the menu closed once the view binds to the new item.