### PR TITLE
Check isSwipeEnabled() before performing a fling action.

### DIFF
--- a/library/src/main/java/com/tubb/smrv/SwipeHorizontalMenuLayout.java
+++ b/library/src/main/java/com/tubb/smrv/SwipeHorizontalMenuLayout.java
@@ -121,7 +121,7 @@ public class SwipeHorizontalMenuLayout extends SwipeMenuLayout {
                 mVelocityTracker.computeCurrentVelocity(1000, mScaledMaximumFlingVelocity);
                 int velocityX = (int) mVelocityTracker.getXVelocity();
                 int velocity = Math.abs(velocityX);
-                if (velocity > mScaledMinimumFlingVelocity) {
+                if (isSwipeEnable() && velocity > mScaledMinimumFlingVelocity) {
                     if (mCurrentSwiper != null) {
                         int duration = getSwipeDuration(ev, velocity);
                         if (mCurrentSwiper instanceof RightHorizontalSwiper) {

--- a/library/src/main/java/com/tubb/smrv/SwipeVerticalMenuLayout.java
+++ b/library/src/main/java/com/tubb/smrv/SwipeVerticalMenuLayout.java
@@ -120,7 +120,7 @@ public class SwipeVerticalMenuLayout extends SwipeMenuLayout {
                 mVelocityTracker.computeCurrentVelocity(1000, mScaledMaximumFlingVelocity);
                 int velocityY = (int) mVelocityTracker.getYVelocity();
                 int velocity = Math.abs(velocityY);
-                if (velocity > mScaledMinimumFlingVelocity) {
+                if (isSwipeEnable() && velocity > mScaledMinimumFlingVelocity) {
                     if (mCurrentSwiper != null) {
                         int duration = getSwipeDuration(ev, velocity);
                         if (mCurrentSwiper instanceof BottomVerticalSwiper) {


### PR DESCRIPTION
There is a possible bug, that even if swipe is disabled for the layout, it can be still opened with a fling. If it is not a bug, than probably there should be also an `flingEnabled` property to control this behavior.

Please merge this PR, if this is really a bug, and let me know if this is the expected behavior. Then I will make the appropriate changes, and open a new PR for handling the fling events.